### PR TITLE
Removed Default Keys (bugfix from last pull request)

### DIFF
--- a/jsnox.js
+++ b/jsnox.js
@@ -49,7 +49,7 @@ function parseTagSpec(specString) {
     // Provide the specString as a default key, which can always be overridden
     // by the props hash (for when two siblings have the same specString)
     var tagName = tagMatch[1]
-    keyCount[specString] = keyCount[specString] ? keyCount[specString] + 1 : 1;
+    keyCount[specString] = keyCount[specString] ? keyCount[specString] + 1 : 1
     var uniqueKey = specString + keyCount[specString]
     var props = { key: uniqueKey }
     var classes = []

--- a/jsnox.js
+++ b/jsnox.js
@@ -38,7 +38,7 @@ function parseTagSpec(specString) {
     // Parse tagName, and optional type attribute
     var tagMatch = specString.match(tagNameRegex)
     if (!tagMatch) throw new ParseError(specString)
-
+    var tagName = tagMatch[1]
     var props = {}
     var classes = []
     if (tagMatch[2]) props.type = tagMatch[2]

--- a/jsnox.js
+++ b/jsnox.js
@@ -110,10 +110,12 @@ function jsnox(React, autoKeyGen) {
             props = null
         }
 
-        if (typeof componentType === 'function' && autoKeyGen) {
-            var fakeKey = componentType.displayName || 'customElement'
-            props = props || {}
-            if (!props.key) props.key = fakeKey
+        if (typeof componentType === 'function') {
+            if (autoKeyGen) {
+                var fakeKey = componentType.displayName || 'customElement'
+                props = props || {}
+                if (!props.key) props.key = fakeKey
+            }
         } else {
             // Parse the provided string into a hash of props
             // If componentType is invalid (undefined, empty string, etc),

--- a/jsnox.js
+++ b/jsnox.js
@@ -20,6 +20,13 @@ ParseError.prototype.name = 'JSnoXParseError'
 // from this cache for an increase in performance.
 var specCache = {}
 
+//An object to hold the count of how many times each key is used
+//so far in order to append the count to the key and therefore
+//make each key unique. This avoids any 
+// flattenchildren encountered two children with the same key react
+//type of errors
+var keyCount = {}
+
 // Convert a tag specification string into an object
 // eg. 'input:checkbox#foo.bar[name=asdf]' produces the output:
 // {
@@ -42,7 +49,9 @@ function parseTagSpec(specString) {
     // Provide the specString as a default key, which can always be overridden
     // by the props hash (for when two siblings have the same specString)
     var tagName = tagMatch[1]
-    var props = { key: specString }
+    keyCount[specString] = keyCount[specString] ? keyCount[specString] + 1 : 1;
+    var uniqueKey = specString + keyCount[specString]
+    var props = { key: uniqueKey }
     var classes = []
     if (tagMatch[2]) props.type = tagMatch[2]
     else if (tagName === 'button') props.type = 'button' // Saner default for <button>
@@ -118,6 +127,8 @@ function jsnox(React) {
             // siblings of the same type. Provide a displayName for your custom
             // components to make this more useful (and help with debugging).
             var fakeKey = componentType.displayName || 'customElement'
+            keyCount[fakeKey] = keyCount[fakeKey] ? keyCount[fakeKey] + 1 : 1
+            fakeKey = fakeKey + keyCount[fakeKey]
             props = props || {}
             if (!props.key) props.key = fakeKey
         } else {

--- a/jsnox.js
+++ b/jsnox.js
@@ -4,6 +4,7 @@
 var tagNameRegex = /^([a-z1-6]+)(?:\:([a-z]+))?/    // matches 'input' or 'input:text'
 var propsRegex = /((?:#|\.|@)[\w-]+)|(\[.*?\])/g    // matches all further properties
 var attrRegex = /\[([\w-]+)(?:=([^\]]+))?\]/        // matches '[foo=bar]' or '[foo]'
+var autoKeyGenRegex = /\^$/                         // matches 'anything^' 
 
 // Error subclass to throw for parsing errors
 function ParseError(input) {
@@ -40,7 +41,7 @@ function parseTagSpec(specString, autoKeyGen) {
     var tagName = tagMatch[1]
     var props = {}
     var classes = []
-    if (autoKeyGen) {
+    if (autoKeyGen || specString.match(autoKeyGenRegex)) {
         props.key = specString
     }
     if (tagMatch[2]) props.type = tagMatch[2]
@@ -110,13 +111,7 @@ function jsnox(React, autoKeyGen) {
             props = null
         }
 
-        if (typeof componentType === 'function') {
-            if (autoKeyGen) {
-                var fakeKey = componentType.displayName || 'customElement'
-                props = props || {}
-                if (!props.key) props.key = fakeKey
-            }
-        } else {
+        if (typeof componentType !== 'function') {
             // Parse the provided string into a hash of props
             // If componentType is invalid (undefined, empty string, etc),
             // parseTagSpec should throw.


### PR DESCRIPTION
*Note: same as last pull request that I closed just got a little overzealous last time and deleted one line I shouldn't have which caused some errors*

# Problem

The setting of default keys was causing problems. It often gave two elements the same key in which case React only renders one of them. I initially tried to solve this by adding sequence numbers to the keys but this resulted in React thinking it was a new component every time it rendered because the key got incremented every time. Eventually I realized that if no key was provided, React automatically kept track of the components by incrementing its data-reactid attribute.

By trying to provide default keys, jsnox was breaking the default React behavior. Trying to avoid the "Each child in an array should have a unique key prop" warning by assigning default keys actually led to explicit duplicate keys which is a much bigger problem because the components with duplicate keys that were explicitly assigned don't get displayed.

# Solution

To remedy the problems I was encountering I removed all key setting code from jsnox. A simple fix with the added benefit of making the package smaller and more focused.

# Conclusion

I propose that jsnox should not try to assign keys at all. If a developer is getting warnings about unique keys they should assign keys intentionally as shown here:

http://facebook.github.io/react/docs/multiple-components.html#dynamic-children

Default key assignment is not transparent and causes errors that many people might not understand unless they look at the source code for jsnox. Lets keep it simple and return to the default React behavior regarding keys.